### PR TITLE
viewer: support sideloaded areas

### DIFF
--- a/src/dataStructures.ts
+++ b/src/dataStructures.ts
@@ -70,7 +70,8 @@ export interface ICluster {
     readonly product: string;
     readonly height: number;
     readonly tool: string;
-    readonly isCandidateCluster: boolean;
+    readonly kind: string;
+    readonly prefix: string;
 }
 
 export interface ITTACodon {


### PR DESCRIPTION
Changes expected data structures and handling in the SVG view to support showing protoclusters and regions with extra tool information.